### PR TITLE
Assign functions to the power button

### DIFF
--- a/app/src/main/java/com/android/deskclock/data/AlarmModel.java
+++ b/app/src/main/java/com/android/deskclock/data/AlarmModel.java
@@ -71,6 +71,11 @@ final class AlarmModel {
         return mSettingsModel.getAlarmVolumeButtonBehavior();
     }
 
+    AlarmVolumeButtonBehavior getAlarmPowerButtonBehavior() {
+        return mSettingsModel.getAlarmPowerButtonBehavior();
+    }
+
+    
     int getAlarmTimeout() {
         return mSettingsModel.getAlarmTimeout();
     }


### PR DESCRIPTION
Assign all "dismiss, pospone or nothing" functions of the alarm to the power button.